### PR TITLE
Update module manifest

### DIFF
--- a/CSharp/VirtoCommerce.MemberExModule.Template/Core/Core.csproj
+++ b/CSharp/VirtoCommerce.MemberExModule.Template/Core/Core.csproj
@@ -45,8 +45,8 @@
     <Reference Include="VirtoCommerce.Domain, Version=2.25.32.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>$nugetpackagesfolder$VirtoCommerce.Domain.2.25.32\lib\net461\VirtoCommerce.Domain.dll</HintPath>
     </Reference>
-    <Reference Include="VirtoCommerce.Platform.Core, Version=2.13.55.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>$nugetpackagesfolder$VirtoCommerce.Platform.Core.2.13.55\lib\net461\VirtoCommerce.Platform.Core.dll</HintPath>
+    <Reference Include="VirtoCommerce.Platform.Core, Version=2.13.56.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>$nugetpackagesfolder$VirtoCommerce.Platform.Core.2.13.56\lib\net461\VirtoCommerce.Platform.Core.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/CSharp/VirtoCommerce.MemberExModule.Template/Core/Core.csproj
+++ b/CSharp/VirtoCommerce.MemberExModule.Template/Core/Core.csproj
@@ -32,7 +32,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>$nugetpackagesfolder$Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>$nugetpackagesfolder$Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/CSharp/VirtoCommerce.MemberExModule.Template/Core/_packages.config
+++ b/CSharp/VirtoCommerce.MemberExModule.Template/Core/_packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net461" />
+  <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net461" />
   <package id="VirtoCommerce.Domain" version="2.25.32" targetFramework="net461" />
   <package id="VirtoCommerce.Platform.Core" version="2.13.55" targetFramework="net461" />
 </packages>

--- a/CSharp/VirtoCommerce.MemberExModule.Template/Core/_packages.config
+++ b/CSharp/VirtoCommerce.MemberExModule.Template/Core/_packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net461" />
   <package id="VirtoCommerce.Domain" version="2.25.32" targetFramework="net461" />
-  <package id="VirtoCommerce.Platform.Core" version="2.13.55" targetFramework="net461" />
+  <package id="VirtoCommerce.Platform.Core" version="2.13.56" targetFramework="net461" />
 </packages>

--- a/CSharp/VirtoCommerce.MemberExModule.Template/Data/Data.csproj
+++ b/CSharp/VirtoCommerce.MemberExModule.Template/Data/Data.csproj
@@ -37,17 +37,17 @@
     <Reference Include="CacheManager.Core, Version=0.8.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>$nugetpackagesfolder$CacheManager.Core.0.8.0\lib\net45\CacheManager.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Common.Logging, Version=3.3.1.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
-      <HintPath>$nugetpackagesfolder$Common.Logging.3.3.1\lib\net40\Common.Logging.dll</HintPath>
+    <Reference Include="Common.Logging, Version=3.4.1.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
+      <HintPath>$nugetpackagesfolder$Common.Logging.3.4.1\lib\net40\Common.Logging.dll</HintPath>
     </Reference>
-    <Reference Include="Common.Logging.Core, Version=3.3.1.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
-      <HintPath>$nugetpackagesfolder$Common.Logging.Core.3.3.1\lib\net40\Common.Logging.Core.dll</HintPath>
+    <Reference Include="Common.Logging.Core, Version=3.4.1.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
+      <HintPath>$nugetpackagesfolder$Common.Logging.Core.3.4.1\lib\net40\Common.Logging.Core.dll</HintPath>
     </Reference>
     <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
-      <HintPath>$nugetpackagesfolder$EntityFramework.6.2.0\lib\net45\EntityFramework.dll</HintPath>
+      <HintPath>$nugetpackagesfolder$EntityFramework.6.3.0\lib\net45\EntityFramework.dll</HintPath>
     </Reference>
     <Reference Include="EntityFramework.SqlServer, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
-      <HintPath>$nugetpackagesfolder$EntityFramework.6.2.0\lib\net45\EntityFramework.SqlServer.dll</HintPath>
+      <HintPath>$nugetpackagesfolder$EntityFramework.6.3.0\lib\net45\EntityFramework.SqlServer.dll</HintPath>
     </Reference>
     <Reference Include="LinqKit, Version=1.1.9.0, Culture=neutral, PublicKeyToken=bc217f8844052a91, processorArchitecture=MSIL">
       <HintPath>$nugetpackagesfolder$LinqKit.1.1.9.0\lib\net45\LinqKit.dll</HintPath>
@@ -78,11 +78,11 @@
     <Reference Include="VirtoCommerce.Domain, Version=2.25.32.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>$nugetpackagesfolder$VirtoCommerce.Domain.2.25.32\lib\net461\VirtoCommerce.Domain.dll</HintPath>
     </Reference>
-    <Reference Include="VirtoCommerce.Platform.Core, Version=2.13.55.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>$nugetpackagesfolder$VirtoCommerce.Platform.Core.2.13.55\lib\net461\VirtoCommerce.Platform.Core.dll</HintPath>
+    <Reference Include="VirtoCommerce.Platform.Core, Version=2.13.56.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>$nugetpackagesfolder$VirtoCommerce.Platform.Core.2.13.56\lib\net461\VirtoCommerce.Platform.Core.dll</HintPath>
     </Reference>
-    <Reference Include="VirtoCommerce.Platform.Data, Version=2.13.55.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>$nugetpackagesfolder$VirtoCommerce.Platform.Data.2.13.55\lib\net461\VirtoCommerce.Platform.Data.dll</HintPath>
+    <Reference Include="VirtoCommerce.Platform.Data, Version=2.13.56.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>$nugetpackagesfolder$VirtoCommerce.Platform.Data.2.13.56\lib\net461\VirtoCommerce.Platform.Data.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/CSharp/VirtoCommerce.MemberExModule.Template/Data/Data.csproj
+++ b/CSharp/VirtoCommerce.MemberExModule.Template/Data/Data.csproj
@@ -53,7 +53,7 @@
       <HintPath>$nugetpackagesfolder$LinqKit.1.1.9.0\lib\net45\LinqKit.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>$nugetpackagesfolder$Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>$nugetpackagesfolder$Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="Omu.ValueInjecter, Version=2.3.3.0, Culture=neutral, PublicKeyToken=c7694541b0ac80e4, processorArchitecture=MSIL">
       <HintPath>$nugetpackagesfolder$valueinjecter.2.3.3\lib\net35\Omu.ValueInjecter.dll</HintPath>

--- a/CSharp/VirtoCommerce.MemberExModule.Template/Data/_packages.config
+++ b/CSharp/VirtoCommerce.MemberExModule.Template/Data/_packages.config
@@ -2,15 +2,15 @@
 <packages>
   <package id="AutoCompare" version="0.3.0.53" targetFramework="net461" />
   <package id="CacheManager.Core" version="0.8.0" targetFramework="net461" />
-  <package id="Common.Logging" version="3.3.1" targetFramework="net461" />
-  <package id="Common.Logging.Core" version="3.3.1" targetFramework="net461" />
-  <package id="EntityFramework" version="6.2.0" targetFramework="net461" />
+  <package id="Common.Logging" version="3.4.1" targetFramework="net461" />
+  <package id="Common.Logging.Core" version="3.4.1" targetFramework="net461" />
+  <package id="EntityFramework" version="6.3.0" targetFramework="net461" />
   <package id="LinqKit" version="1.1.9.0" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net461" />
   <package id="StackExchange.Redis" version="1.2.6" targetFramework="net461" />
   <package id="valueinjecter" version="2.3.3" targetFramework="net461" />
   <package id="VirtoCommerce.CustomerModule.Data" version="2.14.23" targetFramework="net461" />
   <package id="VirtoCommerce.Domain" version="2.25.32" targetFramework="net461" />
-  <package id="VirtoCommerce.Platform.Core" version="2.13.55" targetFramework="net461" />
-  <package id="VirtoCommerce.Platform.Data" version="2.13.55" targetFramework="net461" />
+  <package id="VirtoCommerce.Platform.Core" version="2.13.56" targetFramework="net461" />
+  <package id="VirtoCommerce.Platform.Data" version="2.13.56" targetFramework="net461" />
 </packages>

--- a/CSharp/VirtoCommerce.MemberExModule.Template/Data/_packages.config
+++ b/CSharp/VirtoCommerce.MemberExModule.Template/Data/_packages.config
@@ -6,7 +6,7 @@
   <package id="Common.Logging.Core" version="3.3.1" targetFramework="net461" />
   <package id="EntityFramework" version="6.2.0" targetFramework="net461" />
   <package id="LinqKit" version="1.1.9.0" targetFramework="net461" />
-  <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net461" />
+  <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net461" />
   <package id="StackExchange.Redis" version="1.2.6" targetFramework="net461" />
   <package id="valueinjecter" version="2.3.3" targetFramework="net461" />
   <package id="VirtoCommerce.CustomerModule.Data" version="2.14.23" targetFramework="net461" />

--- a/CSharp/VirtoCommerce.MemberExModule.Template/Tests/Tests.csproj
+++ b/CSharp/VirtoCommerce.MemberExModule.Template/Tests/Tests.csproj
@@ -44,17 +44,17 @@
     <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
       <HintPath>$nugetpackagesfolder$Castle.Core.4.4.0\lib\net45\Castle.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Common.Logging, Version=3.3.1.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
-      <HintPath>$nugetpackagesfolder$Common.Logging.3.3.1\lib\net40\Common.Logging.dll</HintPath>
+    <Reference Include="Common.Logging, Version=3.4.1.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
+      <HintPath>$nugetpackagesfolder$Common.Logging.3.4.1\lib\net40\Common.Logging.dll</HintPath>
     </Reference>
-    <Reference Include="Common.Logging.Core, Version=3.3.1.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
-      <HintPath>$nugetpackagesfolder$Common.Logging.Core.3.3.1\lib\net40\Common.Logging.Core.dll</HintPath>
+    <Reference Include="Common.Logging.Core, Version=3.4.1.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
+      <HintPath>$nugetpackagesfolder$Common.Logging.Core.3.4.1\lib\net40\Common.Logging.Core.dll</HintPath>
     </Reference>
     <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
-      <HintPath>$nugetpackagesfolder$EntityFramework.6.2.0\lib\net45\EntityFramework.dll</HintPath>
+      <HintPath>$nugetpackagesfolder$EntityFramework.6.3.0\lib\net45\EntityFramework.dll</HintPath>
     </Reference>
     <Reference Include="EntityFramework.SqlServer, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
-      <HintPath>$nugetpackagesfolder$EntityFramework.6.2.0\lib\net45\EntityFramework.SqlServer.dll</HintPath>
+      <HintPath>$nugetpackagesfolder$EntityFramework.6.3.0\lib\net45\EntityFramework.SqlServer.dll</HintPath>
     </Reference>
     <Reference Include="LinqKit, Version=1.1.9.0, Culture=neutral, PublicKeyToken=bc217f8844052a91, processorArchitecture=MSIL">
       <HintPath>$nugetpackagesfolder$LinqKit.1.1.9.0\lib\net45\LinqKit.dll</HintPath>
@@ -94,14 +94,14 @@
     <Reference Include="VirtoCommerce.Domain, Version=2.25.32.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>$nugetpackagesfolder$VirtoCommerce.Domain.2.25.32\lib\net461\VirtoCommerce.Domain.dll</HintPath>
     </Reference>
-    <Reference Include="VirtoCommerce.Platform.Core, Version=2.13.55.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>$nugetpackagesfolder$VirtoCommerce.Platform.Core.2.13.55\lib\net461\VirtoCommerce.Platform.Core.dll</HintPath>
+    <Reference Include="VirtoCommerce.Platform.Core, Version=2.13.56.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>$nugetpackagesfolder$VirtoCommerce.Platform.Core.2.13.56\lib\net461\VirtoCommerce.Platform.Core.dll</HintPath>
     </Reference>
-    <Reference Include="VirtoCommerce.Platform.Data, Version=2.13.55.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>$nugetpackagesfolder$VirtoCommerce.Platform.Data.2.13.55\lib\net461\VirtoCommerce.Platform.Data.dll</HintPath>
+    <Reference Include="VirtoCommerce.Platform.Data, Version=2.13.56.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>$nugetpackagesfolder$VirtoCommerce.Platform.Data.2.13.56\lib\net461\VirtoCommerce.Platform.Data.dll</HintPath>
     </Reference>
-    <Reference Include="VirtoCommerce.Platform.Testing, Version=2.13.55.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>$nugetpackagesfolder$VirtoCommerce.Platform.Testing.2.13.55\lib\net461\VirtoCommerce.Platform.Testing.dll</HintPath>
+    <Reference Include="VirtoCommerce.Platform.Testing, Version=2.13.56.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>$nugetpackagesfolder$VirtoCommerce.Platform.Testing.2.13.56\lib\net461\VirtoCommerce.Platform.Testing.dll</HintPath>
     </Reference>
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <HintPath>$nugetpackagesfolder$xunit.abstractions.2.0.3\lib\net35\xunit.abstractions.dll</HintPath>

--- a/CSharp/VirtoCommerce.MemberExModule.Template/Tests/Tests.csproj
+++ b/CSharp/VirtoCommerce.MemberExModule.Template/Tests/Tests.csproj
@@ -63,7 +63,7 @@
       <HintPath>$nugetpackagesfolder$Moq.4.12.0\lib\net45\Moq.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>$nugetpackagesfolder$Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>$nugetpackagesfolder$Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="Omu.ValueInjecter, Version=2.3.3.0, Culture=neutral, PublicKeyToken=c7694541b0ac80e4, processorArchitecture=MSIL">
       <HintPath>$nugetpackagesfolder$valueinjecter.2.3.3\lib\net35\Omu.ValueInjecter.dll</HintPath>

--- a/CSharp/VirtoCommerce.MemberExModule.Template/Tests/_packages.config
+++ b/CSharp/VirtoCommerce.MemberExModule.Template/Tests/_packages.config
@@ -3,9 +3,9 @@
   <package id="AutoCompare" version="0.3.0.53" targetFramework="net461" />
   <package id="CacheManager.Core" version="0.8.0" targetFramework="net461" />
   <package id="Castle.Core" version="4.4.0" targetFramework="net461" />
-  <package id="Common.Logging" version="3.3.1" targetFramework="net461" />
-  <package id="Common.Logging.Core" version="3.3.1" targetFramework="net461" />
-  <package id="EntityFramework" version="6.2.0" targetFramework="net461" />
+  <package id="Common.Logging" version="3.4.1" targetFramework="net461" />
+  <package id="Common.Logging.Core" version="3.4.1" targetFramework="net461" />
+  <package id="EntityFramework" version="6.3.0" targetFramework="net461" />
   <package id="LinqKit" version="1.1.9.0" targetFramework="net461" />
   <package id="Moq" version="4.12.0" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net461" />
@@ -15,9 +15,9 @@
   <package id="valueinjecter" version="2.3.3" targetFramework="net461" />
   <package id="VirtoCommerce.CustomerModule.Data" version="2.14.23" targetFramework="net461" />
   <package id="VirtoCommerce.Domain" version="2.25.32" targetFramework="net461" />
-  <package id="VirtoCommerce.Platform.Core" version="2.13.55" targetFramework="net461" />
-  <package id="VirtoCommerce.Platform.Data" version="2.13.55" targetFramework="net461" />
-  <package id="VirtoCommerce.Platform.Testing" version="2.13.55" targetFramework="net461" />
+  <package id="VirtoCommerce.Platform.Core" version="2.13.56" targetFramework="net461" />
+  <package id="VirtoCommerce.Platform.Data" version="2.13.56" targetFramework="net461" />
+  <package id="VirtoCommerce.Platform.Testing" version="2.13.56" targetFramework="net461" />
   <package id="xunit" version="2.4.1" targetFramework="net461" />
   <package id="xunit.abstractions" version="2.0.3" targetFramework="net461" />
   <package id="xunit.analyzers" version="0.10.0" targetFramework="net461" />

--- a/CSharp/VirtoCommerce.MemberExModule.Template/Tests/_packages.config
+++ b/CSharp/VirtoCommerce.MemberExModule.Template/Tests/_packages.config
@@ -8,7 +8,7 @@
   <package id="EntityFramework" version="6.2.0" targetFramework="net461" />
   <package id="LinqKit" version="1.1.9.0" targetFramework="net461" />
   <package id="Moq" version="4.12.0" targetFramework="net461" />
-  <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net461" />
+  <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net461" />
   <package id="StackExchange.Redis" version="1.2.6" targetFramework="net461" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.2" targetFramework="net461" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.1" targetFramework="net461" />

--- a/CSharp/VirtoCommerce.MemberExModule.Template/Web/Web.csproj
+++ b/CSharp/VirtoCommerce.MemberExModule.Template/Web/Web.csproj
@@ -84,7 +84,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>$nugetpackagesfolder$Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>$nugetpackagesfolder$Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="Omu.ValueInjecter, Version=2.3.3.0, Culture=neutral, PublicKeyToken=c7694541b0ac80e4, processorArchitecture=MSIL">
       <HintPath>$nugetpackagesfolder$valueinjecter.2.3.3\lib\net35\Omu.ValueInjecter.dll</HintPath>

--- a/CSharp/VirtoCommerce.MemberExModule.Template/Web/Web.csproj
+++ b/CSharp/VirtoCommerce.MemberExModule.Template/Web/Web.csproj
@@ -51,17 +51,17 @@
     <Reference Include="CacheManager.Core, Version=0.8.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>$nugetpackagesfolder$CacheManager.Core.0.8.0\lib\net45\CacheManager.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Common.Logging, Version=3.3.1.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
-      <HintPath>$nugetpackagesfolder$Common.Logging.3.3.1\lib\net40\Common.Logging.dll</HintPath>
+    <Reference Include="Common.Logging, Version=3.4.1.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
+      <HintPath>$nugetpackagesfolder$Common.Logging.3.4.1\lib\net40\Common.Logging.dll</HintPath>
     </Reference>
-    <Reference Include="Common.Logging.Core, Version=3.3.1.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
-      <HintPath>$nugetpackagesfolder$Common.Logging.Core.3.3.1\lib\net40\Common.Logging.Core.dll</HintPath>
+    <Reference Include="Common.Logging.Core, Version=3.4.1.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
+      <HintPath>$nugetpackagesfolder$Common.Logging.Core.3.4.1\lib\net40\Common.Logging.Core.dll</HintPath>
     </Reference>
     <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
-      <HintPath>$nugetpackagesfolder$EntityFramework.6.2.0\lib\net45\EntityFramework.dll</HintPath>
+      <HintPath>$nugetpackagesfolder$EntityFramework.6.3.0\lib\net45\EntityFramework.dll</HintPath>
     </Reference>
     <Reference Include="EntityFramework.SqlServer, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
-      <HintPath>$nugetpackagesfolder$EntityFramework.6.2.0\lib\net45\EntityFramework.SqlServer.dll</HintPath>
+      <HintPath>$nugetpackagesfolder$EntityFramework.6.3.0\lib\net45\EntityFramework.SqlServer.dll</HintPath>
     </Reference>
     <Reference Include="LinqKit, Version=1.1.9.0, Culture=neutral, PublicKeyToken=bc217f8844052a91, processorArchitecture=MSIL">
       <HintPath>$nugetpackagesfolder$LinqKit.1.1.9.0\lib\net45\LinqKit.dll</HintPath>
@@ -120,11 +120,11 @@
     <Reference Include="VirtoCommerce.Domain, Version=2.25.32.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>$nugetpackagesfolder$VirtoCommerce.Domain.2.25.32\lib\net461\VirtoCommerce.Domain.dll</HintPath>
     </Reference>
-    <Reference Include="VirtoCommerce.Platform.Core, Version=2.13.55.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>$nugetpackagesfolder$VirtoCommerce.Platform.Core.2.13.55\lib\net461\VirtoCommerce.Platform.Core.dll</HintPath>
+    <Reference Include="VirtoCommerce.Platform.Core, Version=2.13.56.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>$nugetpackagesfolder$VirtoCommerce.Platform.Core.2.13.56\lib\net461\VirtoCommerce.Platform.Core.dll</HintPath>
     </Reference>
-    <Reference Include="VirtoCommerce.Platform.Data, Version=2.13.55.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>$nugetpackagesfolder$VirtoCommerce.Platform.Data.2.13.55\lib\net461\VirtoCommerce.Platform.Data.dll</HintPath>
+    <Reference Include="VirtoCommerce.Platform.Data, Version=2.13.56.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>$nugetpackagesfolder$VirtoCommerce.Platform.Data.2.13.56\lib\net461\VirtoCommerce.Platform.Data.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/CSharp/VirtoCommerce.MemberExModule.Template/Web/_packages.config
+++ b/CSharp/VirtoCommerce.MemberExModule.Template/Web/_packages.config
@@ -10,7 +10,7 @@
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.7" targetFramework="net461" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.7" targetFramework="net461" />
   <package id="MSBuildTasks" version="1.5.0.235" targetFramework="net461" developmentDependency="true" />
-  <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net461" />
+  <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net461" />
   <package id="StackExchange.Redis" version="1.2.6" targetFramework="net461" />
   <package id="Unity" version="4.0.1" targetFramework="net461" />
   <package id="valueinjecter" version="2.3.3" targetFramework="net461" />

--- a/CSharp/VirtoCommerce.MemberExModule.Template/Web/_packages.config
+++ b/CSharp/VirtoCommerce.MemberExModule.Template/Web/_packages.config
@@ -2,10 +2,10 @@
 <packages>
   <package id="AutoCompare" version="0.3.0.53" targetFramework="net461" />
   <package id="CacheManager.Core" version="0.8.0" targetFramework="net461" />
-  <package id="Common.Logging" version="3.3.1" targetFramework="net461" />
-  <package id="Common.Logging.Core" version="3.3.1" targetFramework="net461" />
+  <package id="Common.Logging" version="3.4.1" targetFramework="net461" />
+  <package id="Common.Logging.Core" version="3.4.1" targetFramework="net461" />
   <package id="CommonServiceLocator" version="1.3" targetFramework="net461" />
-  <package id="EntityFramework" version="6.2.0" targetFramework="net461" />
+  <package id="EntityFramework" version="6.3.0" targetFramework="net461" />
   <package id="LinqKit" version="1.1.9.0" targetFramework="net461" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.7" targetFramework="net461" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.7" targetFramework="net461" />
@@ -17,6 +17,6 @@
   <package id="VirtoCommerce.CustomerModule.Data" version="2.14.23" targetFramework="net461" />
   <package id="VirtoCommerce.Domain" version="2.25.32" targetFramework="net461" />
   <package id="VirtoCommerce.Module" version="0.18.0" targetFramework="net461" developmentDependency="true" />
-  <package id="VirtoCommerce.Platform.Core" version="2.13.55" targetFramework="net461" />
-  <package id="VirtoCommerce.Platform.Data" version="2.13.55" targetFramework="net461" />
+  <package id="VirtoCommerce.Platform.Core" version="2.13.56" targetFramework="net461" />
+  <package id="VirtoCommerce.Platform.Data" version="2.13.56" targetFramework="net461" />
 </packages>

--- a/CSharp/VirtoCommerce.MemberExModule.Template/Web/module.manifest
+++ b/CSharp/VirtoCommerce.MemberExModule.Template/Web/module.manifest
@@ -2,7 +2,7 @@
 <module>
     <id>$ext_safeprojectname$</id>
     <version>1.0.0</version>
-    <platformVersion>2.13.55</platformVersion>
+    <platformVersion>2.13.56</platformVersion>
     <dependencies>
         <dependency id="VirtoCommerce.Core" version="2.25.32" />
         <dependency id="VirtoCommerce.Customer" version="2.14.23" />

--- a/CSharp/VirtoCommerce.Module.Template/Core/Core.csproj
+++ b/CSharp/VirtoCommerce.Module.Template/Core/Core.csproj
@@ -45,8 +45,8 @@
     <Reference Include="VirtoCommerce.Domain, Version=2.25.32.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>$nugetpackagesfolder$VirtoCommerce.Domain.2.25.32\lib\net461\VirtoCommerce.Domain.dll</HintPath>
     </Reference>
-    <Reference Include="VirtoCommerce.Platform.Core, Version=2.13.55.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>$nugetpackagesfolder$VirtoCommerce.Platform.Core.2.13.55\lib\net461\VirtoCommerce.Platform.Core.dll</HintPath>
+    <Reference Include="VirtoCommerce.Platform.Core, Version=2.13.56.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>$nugetpackagesfolder$VirtoCommerce.Platform.Core.2.13.56\lib\net461\VirtoCommerce.Platform.Core.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/CSharp/VirtoCommerce.Module.Template/Core/Core.csproj
+++ b/CSharp/VirtoCommerce.Module.Template/Core/Core.csproj
@@ -32,7 +32,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>$nugetpackagesfolder$Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>$nugetpackagesfolder$Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/CSharp/VirtoCommerce.Module.Template/Core/_packages.config
+++ b/CSharp/VirtoCommerce.Module.Template/Core/_packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net461" />
   <package id="VirtoCommerce.Domain" version="2.25.32" targetFramework="net461" />
-  <package id="VirtoCommerce.Platform.Core" version="2.13.55" targetFramework="net461" />
+  <package id="VirtoCommerce.Platform.Core" version="2.13.56" targetFramework="net461" />
 </packages>

--- a/CSharp/VirtoCommerce.Module.Template/Core/_packages.config
+++ b/CSharp/VirtoCommerce.Module.Template/Core/_packages.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net461" />
+  <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net461" />
   <package id="VirtoCommerce.Domain" version="2.25.32" targetFramework="net461" />
   <package id="VirtoCommerce.Platform.Core" version="2.13.55" targetFramework="net461" />
 </packages>

--- a/CSharp/VirtoCommerce.Module.Template/Data/Data.csproj
+++ b/CSharp/VirtoCommerce.Module.Template/Data/Data.csproj
@@ -34,17 +34,17 @@
     <Reference Include="CacheManager.Core, Version=0.8.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>$nugetpackagesfolder$CacheManager.Core.0.8.0\lib\net45\CacheManager.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Common.Logging, Version=3.3.1.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
-      <HintPath>$nugetpackagesfolder$Common.Logging.3.3.1\lib\net40\Common.Logging.dll</HintPath>
+    <Reference Include="Common.Logging, Version=3.4.1.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
+      <HintPath>$nugetpackagesfolder$Common.Logging.3.4.1\lib\net40\Common.Logging.dll</HintPath>
     </Reference>
-    <Reference Include="Common.Logging.Core, Version=3.3.1.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
-      <HintPath>$nugetpackagesfolder$Common.Logging.Core.3.3.1\lib\net40\Common.Logging.Core.dll</HintPath>
+    <Reference Include="Common.Logging.Core, Version=3.4.1.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
+      <HintPath>$nugetpackagesfolder$Common.Logging.Core.3.4.1\lib\net40\Common.Logging.Core.dll</HintPath>
     </Reference>
     <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
-      <HintPath>$nugetpackagesfolder$EntityFramework.6.2.0\lib\net45\EntityFramework.dll</HintPath>
+      <HintPath>$nugetpackagesfolder$EntityFramework.6.3.0\lib\net45\EntityFramework.dll</HintPath>
     </Reference>
     <Reference Include="EntityFramework.SqlServer, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
-      <HintPath>$nugetpackagesfolder$EntityFramework.6.2.0\lib\net45\EntityFramework.SqlServer.dll</HintPath>
+      <HintPath>$nugetpackagesfolder$EntityFramework.6.3.0\lib\net45\EntityFramework.SqlServer.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>$nugetpackagesfolder$Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
@@ -65,11 +65,11 @@
     <Reference Include="VirtoCommerce.Domain, Version=2.25.32.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>$nugetpackagesfolder$VirtoCommerce.Domain.2.25.32\lib\net461\VirtoCommerce.Domain.dll</HintPath>
     </Reference>
-    <Reference Include="VirtoCommerce.Platform.Core, Version=2.13.55.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>$nugetpackagesfolder$VirtoCommerce.Platform.Core.2.13.55\lib\net461\VirtoCommerce.Platform.Core.dll</HintPath>
+    <Reference Include="VirtoCommerce.Platform.Core, Version=2.13.56.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>$nugetpackagesfolder$VirtoCommerce.Platform.Core.2.13.56\lib\net461\VirtoCommerce.Platform.Core.dll</HintPath>
     </Reference>
-    <Reference Include="VirtoCommerce.Platform.Data, Version=2.13.55.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>$nugetpackagesfolder$VirtoCommerce.Platform.Data.2.13.55\lib\net461\VirtoCommerce.Platform.Data.dll</HintPath>
+    <Reference Include="VirtoCommerce.Platform.Data, Version=2.13.56.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>$nugetpackagesfolder$VirtoCommerce.Platform.Data.2.13.56\lib\net461\VirtoCommerce.Platform.Data.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/CSharp/VirtoCommerce.Module.Template/Data/Data.csproj
+++ b/CSharp/VirtoCommerce.Module.Template/Data/Data.csproj
@@ -47,7 +47,7 @@
       <HintPath>$nugetpackagesfolder$EntityFramework.6.2.0\lib\net45\EntityFramework.SqlServer.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>$nugetpackagesfolder$Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>$nugetpackagesfolder$Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="Omu.ValueInjecter, Version=2.3.3.0, Culture=neutral, PublicKeyToken=c7694541b0ac80e4, processorArchitecture=MSIL">
       <HintPath>$nugetpackagesfolder$valueinjecter.2.3.3\lib\net35\Omu.ValueInjecter.dll</HintPath>

--- a/CSharp/VirtoCommerce.Module.Template/Data/_packages.config
+++ b/CSharp/VirtoCommerce.Module.Template/Data/_packages.config
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CacheManager.Core" version="0.8.0" targetFramework="net461" />
-  <package id="Common.Logging" version="3.3.1" targetFramework="net461" />
-  <package id="Common.Logging.Core" version="3.3.1" targetFramework="net461" />
-  <package id="EntityFramework" version="6.2.0" targetFramework="net461" />
+  <package id="Common.Logging" version="3.4.1" targetFramework="net461" />
+  <package id="Common.Logging.Core" version="3.4.1" targetFramework="net461" />
+  <package id="EntityFramework" version="6.3.0" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net461" />
   <package id="valueinjecter" version="2.3.3" targetFramework="net461" />
   <package id="VirtoCommerce.Domain" version="2.25.32" targetFramework="net461" />
-  <package id="VirtoCommerce.Platform.Core" version="2.13.55" targetFramework="net461" />
-  <package id="VirtoCommerce.Platform.Data" version="2.13.55" targetFramework="net461" />
+  <package id="VirtoCommerce.Platform.Core" version="2.13.56" targetFramework="net461" />
+  <package id="VirtoCommerce.Platform.Data" version="2.13.56" targetFramework="net461" />
 </packages>

--- a/CSharp/VirtoCommerce.Module.Template/Data/_packages.config
+++ b/CSharp/VirtoCommerce.Module.Template/Data/_packages.config
@@ -4,7 +4,7 @@
   <package id="Common.Logging" version="3.3.1" targetFramework="net461" />
   <package id="Common.Logging.Core" version="3.3.1" targetFramework="net461" />
   <package id="EntityFramework" version="6.2.0" targetFramework="net461" />
-  <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net461" />
+  <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net461" />
   <package id="valueinjecter" version="2.3.3" targetFramework="net461" />
   <package id="VirtoCommerce.Domain" version="2.25.32" targetFramework="net461" />
   <package id="VirtoCommerce.Platform.Core" version="2.13.55" targetFramework="net461" />

--- a/CSharp/VirtoCommerce.Module.Template/Tests/Tests.csproj
+++ b/CSharp/VirtoCommerce.Module.Template/Tests/Tests.csproj
@@ -57,7 +57,7 @@
       <HintPath>$nugetpackagesfolder$EntityFramework.6.2.0\lib\net45\EntityFramework.SqlServer.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>$nugetpackagesfolder$Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>$nugetpackagesfolder$Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="Omu.ValueInjecter, Version=2.3.3.0, Culture=neutral, PublicKeyToken=c7694541b0ac80e4, processorArchitecture=MSIL">
       <HintPath>$nugetpackagesfolder$valueinjecter.2.3.3\lib\net35\Omu.ValueInjecter.dll</HintPath>

--- a/CSharp/VirtoCommerce.Module.Template/Tests/Tests.csproj
+++ b/CSharp/VirtoCommerce.Module.Template/Tests/Tests.csproj
@@ -41,20 +41,20 @@
     <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
       <HintPath>$nugetpackagesfolder$Castle.Core.4.4.0\lib\net45\Castle.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Common.Logging, Version=3.3.1.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
-      <HintPath>$nugetpackagesfolder$Common.Logging.3.3.1\lib\net40\Common.Logging.dll</HintPath>
+    <Reference Include="Common.Logging, Version=3.4.1.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
+      <HintPath>$nugetpackagesfolder$Common.Logging.3.4.1\lib\net40\Common.Logging.dll</HintPath>
     </Reference>
-    <Reference Include="Common.Logging.Core, Version=3.3.1.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
-      <HintPath>$nugetpackagesfolder$Common.Logging.Core.3.3.1\lib\net40\Common.Logging.Core.dll</HintPath>
+    <Reference Include="Common.Logging.Core, Version=3.4.1.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
+      <HintPath>$nugetpackagesfolder$Common.Logging.Core.3.4.1\lib\net40\Common.Logging.Core.dll</HintPath>
     </Reference>
     <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
-      <HintPath>$nugetpackagesfolder$EntityFramework.6.2.0\lib\net45\EntityFramework.dll</HintPath>
+      <HintPath>$nugetpackagesfolder$EntityFramework.6.3.0\lib\net45\EntityFramework.dll</HintPath>
     </Reference>
     <Reference Include="Moq, Version=4.12.0.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
       <HintPath>$nugetpackagesfolder$Moq.4.12.0\lib\net45\Moq.dll</HintPath>
     </Reference>
     <Reference Include="EntityFramework.SqlServer, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
-      <HintPath>$nugetpackagesfolder$EntityFramework.6.2.0\lib\net45\EntityFramework.SqlServer.dll</HintPath>
+      <HintPath>$nugetpackagesfolder$EntityFramework.6.3.0\lib\net45\EntityFramework.SqlServer.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>$nugetpackagesfolder$Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
@@ -81,14 +81,14 @@
     <Reference Include="VirtoCommerce.Domain, Version=2.25.32.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>$nugetpackagesfolder$VirtoCommerce.Domain.2.25.32\lib\net461\VirtoCommerce.Domain.dll</HintPath>
     </Reference>
-    <Reference Include="VirtoCommerce.Platform.Core, Version=2.13.55.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>$nugetpackagesfolder$VirtoCommerce.Platform.Core.2.13.55\lib\net461\VirtoCommerce.Platform.Core.dll</HintPath>
+    <Reference Include="VirtoCommerce.Platform.Core, Version=2.13.56.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>$nugetpackagesfolder$VirtoCommerce.Platform.Core.2.13.56\lib\net461\VirtoCommerce.Platform.Core.dll</HintPath>
     </Reference>
-    <Reference Include="VirtoCommerce.Platform.Data, Version=2.13.55.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>$nugetpackagesfolder$VirtoCommerce.Platform.Data.2.13.55\lib\net461\VirtoCommerce.Platform.Data.dll</HintPath>
+    <Reference Include="VirtoCommerce.Platform.Data, Version=2.13.56.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>$nugetpackagesfolder$VirtoCommerce.Platform.Data.2.13.56\lib\net461\VirtoCommerce.Platform.Data.dll</HintPath>
     </Reference>
-    <Reference Include="VirtoCommerce.Platform.Testing, Version=2.13.55.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>$nugetpackagesfolder$VirtoCommerce.Platform.Testing.2.13.55\lib\net461\VirtoCommerce.Platform.Testing.dll</HintPath>
+    <Reference Include="VirtoCommerce.Platform.Testing, Version=2.13.56.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>$nugetpackagesfolder$VirtoCommerce.Platform.Testing.2.13.56\lib\net461\VirtoCommerce.Platform.Testing.dll</HintPath>
     </Reference>
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <HintPath>$nugetpackagesfolder$xunit.abstractions.2.0.3\lib\net35\xunit.abstractions.dll</HintPath>

--- a/CSharp/VirtoCommerce.Module.Template/Tests/_packages.config
+++ b/CSharp/VirtoCommerce.Module.Template/Tests/_packages.config
@@ -2,18 +2,18 @@
 <packages>
   <package id="CacheManager.Core" version="0.8.0" targetFramework="net461" />
   <package id="Castle.Core" version="4.4.0" targetFramework="net461" />
-  <package id="Common.Logging" version="3.3.1" targetFramework="net461" />
-  <package id="Common.Logging.Core" version="3.3.1" targetFramework="net461" />
-  <package id="EntityFramework" version="6.2.0" targetFramework="net461" />
+  <package id="Common.Logging" version="3.4.1" targetFramework="net461" />
+  <package id="Common.Logging.Core" version="3.4.1" targetFramework="net461" />
+  <package id="EntityFramework" version="6.3.0" targetFramework="net461" />
   <package id="Moq" version="4.12.0" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net461" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.2" targetFramework="net461" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.1" targetFramework="net461" />
   <package id="valueinjecter" version="2.3.3" targetFramework="net461" />
   <package id="VirtoCommerce.Domain" version="2.25.32" targetFramework="net461" />
-  <package id="VirtoCommerce.Platform.Core" version="2.13.55" targetFramework="net461" />
-  <package id="VirtoCommerce.Platform.Data" version="2.13.55" targetFramework="net461" />
-  <package id="VirtoCommerce.Platform.Testing" version="2.13.55" targetFramework="net461" />
+  <package id="VirtoCommerce.Platform.Core" version="2.13.56" targetFramework="net461" />
+  <package id="VirtoCommerce.Platform.Data" version="2.13.56" targetFramework="net461" />
+  <package id="VirtoCommerce.Platform.Testing" version="2.13.56" targetFramework="net461" />
   <package id="xunit" version="2.4.1" targetFramework="net461" />
   <package id="xunit.abstractions" version="2.0.3" targetFramework="net461" />
   <package id="xunit.analyzers" version="0.10.0" targetFramework="net461" />

--- a/CSharp/VirtoCommerce.Module.Template/Tests/_packages.config
+++ b/CSharp/VirtoCommerce.Module.Template/Tests/_packages.config
@@ -6,7 +6,7 @@
   <package id="Common.Logging.Core" version="3.3.1" targetFramework="net461" />
   <package id="EntityFramework" version="6.2.0" targetFramework="net461" />
   <package id="Moq" version="4.12.0" targetFramework="net461" />
-  <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net461" />
+  <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net461" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.2" targetFramework="net461" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.1" targetFramework="net461" />
   <package id="valueinjecter" version="2.3.3" targetFramework="net461" />

--- a/CSharp/VirtoCommerce.Module.Template/Web/Web.csproj
+++ b/CSharp/VirtoCommerce.Module.Template/Web/Web.csproj
@@ -48,17 +48,17 @@
     <Reference Include="CacheManager.Core, Version=0.8.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>$nugetpackagesfolder$CacheManager.Core.0.8.0\lib\net45\CacheManager.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Common.Logging, Version=3.3.1.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
-      <HintPath>$nugetpackagesfolder$Common.Logging.3.3.1\lib\net40\Common.Logging.dll</HintPath>
+    <Reference Include="Common.Logging, Version=3.4.1.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
+      <HintPath>$nugetpackagesfolder$Common.Logging.3.4.1\lib\net40\Common.Logging.dll</HintPath>
     </Reference>
-    <Reference Include="Common.Logging.Core, Version=3.3.1.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
-      <HintPath>$nugetpackagesfolder$Common.Logging.Core.3.3.1\lib\net40\Common.Logging.Core.dll</HintPath>
+    <Reference Include="Common.Logging.Core, Version=3.4.1.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
+      <HintPath>$nugetpackagesfolder$Common.Logging.Core.3.4.1\lib\net40\Common.Logging.Core.dll</HintPath>
     </Reference>
     <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
-      <HintPath>$nugetpackagesfolder$EntityFramework.6.2.0\lib\net45\EntityFramework.dll</HintPath>
+      <HintPath>$nugetpackagesfolder$EntityFramework.6.3.0\lib\net45\EntityFramework.dll</HintPath>
     </Reference>
     <Reference Include="EntityFramework.SqlServer, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
-      <HintPath>$nugetpackagesfolder$EntityFramework.6.2.0\lib\net45\EntityFramework.SqlServer.dll</HintPath>
+      <HintPath>$nugetpackagesfolder$EntityFramework.6.3.0\lib\net45\EntityFramework.SqlServer.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.Practices.ServiceLocation, Version=1.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -93,14 +93,11 @@
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System" />
     <Reference Include="System.Data" />
-    <Reference Include="System.Web.Http, Version=5.2.7.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>$nugetpackagesfolder$Microsoft.AspNet.WebApi.Core.5.2.7\lib\net45\System.Web.Http.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System.Drawing" />
     <Reference Include="System.Web" />
     <Reference Include="System.Web.Http, Version=5.2.7.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>$nugetpackagesfolder$Microsoft.AspNet.WebApi.Core.5.2.7\lib\net45\System.Web.Http.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.Xml" />
     <Reference Include="System.Configuration" />
@@ -109,14 +106,14 @@
     <Reference Include="VirtoCommerce.Domain, Version=2.25.32.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>$nugetpackagesfolder$VirtoCommerce.Domain.2.25.32\lib\net461\VirtoCommerce.Domain.dll</HintPath>
     </Reference>
-    <Reference Include="VirtoCommerce.Platform.Core, Version=2.13.55.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>$nugetpackagesfolder$VirtoCommerce.Platform.Core.2.13.55\lib\net461\VirtoCommerce.Platform.Core.dll</HintPath>
+    <Reference Include="VirtoCommerce.Platform.Core, Version=2.13.56.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>$nugetpackagesfolder$VirtoCommerce.Platform.Core.2.13.56\lib\net461\VirtoCommerce.Platform.Core.dll</HintPath>
     </Reference>
-    <Reference Include="VirtoCommerce.Platform.Core.Web, Version=2.13.55.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>$nugetpackagesfolder$VirtoCommerce.Platform.Core.Web.2.13.55\lib\net461\VirtoCommerce.Platform.Core.Web.dll</HintPath>
+    <Reference Include="VirtoCommerce.Platform.Core.Web, Version=2.13.56.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>$nugetpackagesfolder$VirtoCommerce.Platform.Core.Web.2.13.56\lib\net461\VirtoCommerce.Platform.Core.Web.dll</HintPath>
     </Reference>
-    <Reference Include="VirtoCommerce.Platform.Data, Version=2.13.55.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>$nugetpackagesfolder$VirtoCommerce.Platform.Data.2.13.55\lib\net461\VirtoCommerce.Platform.Data.dll</HintPath>
+    <Reference Include="VirtoCommerce.Platform.Data, Version=2.13.56.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>$nugetpackagesfolder$VirtoCommerce.Platform.Data.2.13.56\lib\net461\VirtoCommerce.Platform.Data.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/CSharp/VirtoCommerce.Module.Template/Web/Web.csproj
+++ b/CSharp/VirtoCommerce.Module.Template/Web/Web.csproj
@@ -78,7 +78,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>$nugetpackagesfolder$Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>$nugetpackagesfolder$Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="Omu.ValueInjecter, Version=2.3.3.0, Culture=neutral, PublicKeyToken=c7694541b0ac80e4, processorArchitecture=MSIL">
       <HintPath>$nugetpackagesfolder$valueinjecter.2.3.3\lib\net35\Omu.ValueInjecter.dll</HintPath>

--- a/CSharp/VirtoCommerce.Module.Template/Web/_packages.config
+++ b/CSharp/VirtoCommerce.Module.Template/Web/_packages.config
@@ -8,7 +8,7 @@
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.7" targetFramework="net461" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.7" targetFramework="net461" />
   <package id="MSBuildTasks" version="1.5.0.235" targetFramework="net461" developmentDependency="true" />
-  <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net461" />
+  <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net461" />
   <package id="Unity" version="4.0.1" targetFramework="net461" />
   <package id="valueinjecter" version="2.3.3" targetFramework="net461" />
   <package id="VirtoCommerce.Domain" version="2.25.32" targetFramework="net461" />

--- a/CSharp/VirtoCommerce.Module.Template/Web/_packages.config
+++ b/CSharp/VirtoCommerce.Module.Template/Web/_packages.config
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CacheManager.Core" version="0.8.0" targetFramework="net461" />
-  <package id="Common.Logging" version="3.3.1" targetFramework="net461" />
-  <package id="Common.Logging.Core" version="3.3.1" targetFramework="net461" />
+  <package id="Common.Logging" version="3.4.1" targetFramework="net461" />
+  <package id="Common.Logging.Core" version="3.4.1" targetFramework="net461" />
   <package id="CommonServiceLocator" version="1.3" targetFramework="net461" />
-  <package id="EntityFramework" version="6.2.0" targetFramework="net461" />
+  <package id="EntityFramework" version="6.3.0" targetFramework="net461" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.7" targetFramework="net461" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.7" targetFramework="net461" />
   <package id="MSBuildTasks" version="1.5.0.235" targetFramework="net461" developmentDependency="true" />
@@ -13,7 +13,7 @@
   <package id="valueinjecter" version="2.3.3" targetFramework="net461" />
   <package id="VirtoCommerce.Domain" version="2.25.32" targetFramework="net461" />
   <package id="VirtoCommerce.Module" version="0.18.0" targetFramework="net461" developmentDependency="true" />
-  <package id="VirtoCommerce.Platform.Core" version="2.13.55" targetFramework="net461" />
-  <package id="VirtoCommerce.Platform.Core.Web" version="2.13.55" targetFramework="net461" />
-  <package id="VirtoCommerce.Platform.Data" version="2.13.55" targetFramework="net461" />
+  <package id="VirtoCommerce.Platform.Core" version="2.13.56" targetFramework="net461" />
+  <package id="VirtoCommerce.Platform.Core.Web" version="2.13.56" targetFramework="net461" />
+  <package id="VirtoCommerce.Platform.Data" version="2.13.56" targetFramework="net461" />
 </packages>

--- a/CSharp/VirtoCommerce.Module.Template/Web/module.manifest
+++ b/CSharp/VirtoCommerce.Module.Template/Web/module.manifest
@@ -2,7 +2,7 @@
 <module>
     <id>$ext_safeprojectname$</id>
     <version>1.0.0</version>
-    <platformVersion>2.13.55</platformVersion>
+    <platformVersion>2.13.56</platformVersion>
     <dependencies>
         <dependency id="VirtoCommerce.Core" version="2.25.32" />
     </dependencies>

--- a/CSharp/VirtoCommerce.Module.Template/Web/module.manifest
+++ b/CSharp/VirtoCommerce.Module.Template/Web/module.manifest
@@ -31,7 +31,7 @@
     </scripts>
 
     <settings>
-        <group name="General">
+        <group name="$ext_safeprojectname$|General">
             <setting>
                 <name>$ext_safeprojectname$.General.String</name>
                 <valueType>string</valueType>
@@ -61,7 +61,7 @@
                 <description>A decimal setting</description>
             </setting>
         </group>
-        <group name="Advanced">
+        <group name="$ext_safeprojectname$|Advanced">
             <setting>
                 <name>$ext_safeprojectname$.Advanced.Boolean1</name>
                 <valueType>boolean</valueType>

--- a/CSharp/VirtoCommerce.OrderExModule.Template/Core/Core.csproj
+++ b/CSharp/VirtoCommerce.OrderExModule.Template/Core/Core.csproj
@@ -32,7 +32,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>$nugetpackagesfolder$Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>$nugetpackagesfolder$Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />

--- a/CSharp/VirtoCommerce.OrderExModule.Template/Core/Core.csproj
+++ b/CSharp/VirtoCommerce.OrderExModule.Template/Core/Core.csproj
@@ -48,8 +48,8 @@
     <Reference Include="VirtoCommerce.Domain, Version=2.25.32.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>$nugetpackagesfolder$VirtoCommerce.Domain.2.25.32\lib\net461\VirtoCommerce.Domain.dll</HintPath>
     </Reference>
-    <Reference Include="VirtoCommerce.Platform.Core, Version=2.13.55.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>$nugetpackagesfolder$VirtoCommerce.Platform.Core.2.13.55\lib\net461\VirtoCommerce.Platform.Core.dll</HintPath>
+    <Reference Include="VirtoCommerce.Platform.Core, Version=2.13.56.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>$nugetpackagesfolder$VirtoCommerce.Platform.Core.2.13.56\lib\net461\VirtoCommerce.Platform.Core.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/CSharp/VirtoCommerce.OrderExModule.Template/Core/_packages.config
+++ b/CSharp/VirtoCommerce.OrderExModule.Template/Core/_packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net461" />
+  <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net461" />
   <package id="VirtoCommerce.Domain" version="2.25.32" targetFramework="net461" />
   <package id="VirtoCommerce.Platform.Core" version="2.13.55" targetFramework="net461" />
 </packages>

--- a/CSharp/VirtoCommerce.OrderExModule.Template/Core/_packages.config
+++ b/CSharp/VirtoCommerce.OrderExModule.Template/Core/_packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net461" />
   <package id="VirtoCommerce.Domain" version="2.25.32" targetFramework="net461" />
-  <package id="VirtoCommerce.Platform.Core" version="2.13.55" targetFramework="net461" />
+  <package id="VirtoCommerce.Platform.Core" version="2.13.56" targetFramework="net461" />
 </packages>

--- a/CSharp/VirtoCommerce.OrderExModule.Template/Data/Data.csproj
+++ b/CSharp/VirtoCommerce.OrderExModule.Template/Data/Data.csproj
@@ -37,17 +37,17 @@
     <Reference Include="CacheManager.Core, Version=0.8.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>$nugetpackagesfolder$CacheManager.Core.0.8.0\lib\net45\CacheManager.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Common.Logging, Version=3.3.1.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
-      <HintPath>$nugetpackagesfolder$Common.Logging.3.3.1\lib\net40\Common.Logging.dll</HintPath>
+    <Reference Include="Common.Logging, Version=3.4.1.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
+      <HintPath>$nugetpackagesfolder$Common.Logging.3.4.1\lib\net40\Common.Logging.dll</HintPath>
     </Reference>
-    <Reference Include="Common.Logging.Core, Version=3.3.1.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
-      <HintPath>$nugetpackagesfolder$Common.Logging.Core.3.3.1\lib\net40\Common.Logging.Core.dll</HintPath>
+    <Reference Include="Common.Logging.Core, Version=3.4.1.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
+      <HintPath>$nugetpackagesfolder$Common.Logging.Core.3.4.1\lib\net40\Common.Logging.Core.dll</HintPath>
     </Reference>
     <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
-      <HintPath>$nugetpackagesfolder$EntityFramework.6.2.0\lib\net45\EntityFramework.dll</HintPath>
+      <HintPath>$nugetpackagesfolder$EntityFramework.6.3.0\lib\net45\EntityFramework.dll</HintPath>
     </Reference>
     <Reference Include="EntityFramework.SqlServer, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
-      <HintPath>$nugetpackagesfolder$EntityFramework.6.2.0\lib\net45\EntityFramework.SqlServer.dll</HintPath>
+      <HintPath>$nugetpackagesfolder$EntityFramework.6.3.0\lib\net45\EntityFramework.SqlServer.dll</HintPath>
     </Reference>
     <Reference Include="Hangfire.Core, Version=1.6.17.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>$nugetpackagesfolder$Hangfire.Core.1.6.17\lib\net45\Hangfire.Core.dll</HintPath>
@@ -60,6 +60,9 @@
     </Reference>
     <Reference Include="Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f0ebd12fd5e55cc5, processorArchitecture=MSIL">
       <HintPath>$nugetpackagesfolder$Owin.1.0\lib\net40\Owin.dll</HintPath>
+    </Reference>
+    <Reference Include="StackExchange.Redis, Version=1.2.6.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\StackExchange.Redis.1.2.6\lib\net46\StackExchange.Redis.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
@@ -80,11 +83,11 @@
     <Reference Include="VirtoCommerce.OrderModule.Data, Version=2.17.29.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>$nugetpackagesfolder$VirtoCommerce.OrderModule.Data.2.17.29\lib\net461\VirtoCommerce.OrderModule.Data.dll</HintPath>
     </Reference>
-    <Reference Include="VirtoCommerce.Platform.Core, Version=2.13.55.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>$nugetpackagesfolder$VirtoCommerce.Platform.Core.2.13.55\lib\net461\VirtoCommerce.Platform.Core.dll</HintPath>
+    <Reference Include="VirtoCommerce.Platform.Core, Version=2.13.56.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>$nugetpackagesfolder$VirtoCommerce.Platform.Core.2.13.56\lib\net461\VirtoCommerce.Platform.Core.dll</HintPath>
     </Reference>
-    <Reference Include="VirtoCommerce.Platform.Data, Version=2.13.55.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>$nugetpackagesfolder$VirtoCommerce.Platform.Data.2.13.55\lib\net461\VirtoCommerce.Platform.Data.dll</HintPath>
+    <Reference Include="VirtoCommerce.Platform.Data, Version=2.13.56.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>$nugetpackagesfolder$VirtoCommerce.Platform.Data.2.13.56\lib\net461\VirtoCommerce.Platform.Data.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/CSharp/VirtoCommerce.OrderExModule.Template/Data/Data.csproj
+++ b/CSharp/VirtoCommerce.OrderExModule.Template/Data/Data.csproj
@@ -53,7 +53,7 @@
       <HintPath>$nugetpackagesfolder$Hangfire.Core.1.6.17\lib\net45\Hangfire.Core.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>$nugetpackagesfolder$Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>$nugetpackagesfolder$Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="Omu.ValueInjecter, Version=2.3.3.0, Culture=neutral, PublicKeyToken=c7694541b0ac80e4, processorArchitecture=MSIL">
       <HintPath>$nugetpackagesfolder$valueinjecter.2.3.3\lib\net35\Omu.ValueInjecter.dll</HintPath>

--- a/CSharp/VirtoCommerce.OrderExModule.Template/Data/_packages.config
+++ b/CSharp/VirtoCommerce.OrderExModule.Template/Data/_packages.config
@@ -2,16 +2,17 @@
 <packages>
   <package id="AutoCompare" version="0.3.0.53" targetFramework="net461" />
   <package id="CacheManager.Core" version="0.8.0" targetFramework="net461" />
-  <package id="Common.Logging" version="3.3.1" targetFramework="net461" />
-  <package id="Common.Logging.Core" version="3.3.1" targetFramework="net461" />
-  <package id="EntityFramework" version="6.2.0" targetFramework="net461" />
+  <package id="Common.Logging" version="3.4.1" targetFramework="net461" />
+  <package id="Common.Logging.Core" version="3.4.1" targetFramework="net461" />
+  <package id="EntityFramework" version="6.3.0" targetFramework="net461" />
   <package id="Hangfire.Core" version="1.6.17" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net461" />
   <package id="Owin" version="1.0" targetFramework="net461" />
+  <package id="StackExchange.Redis" version="1.2.6" targetFramework="net461" />
   <package id="valueinjecter" version="2.3.3" targetFramework="net461" />
   <package id="VirtoCommerce.CartModule.Data" version="2.17.1" targetFramework="net461" />
   <package id="VirtoCommerce.Domain" version="2.25.32" targetFramework="net461" />
   <package id="VirtoCommerce.OrderModule.Data" version="2.17.29" targetFramework="net461" />
-  <package id="VirtoCommerce.Platform.Core" version="2.13.55" targetFramework="net461" />
-  <package id="VirtoCommerce.Platform.Data" version="2.13.55" targetFramework="net461" />
+  <package id="VirtoCommerce.Platform.Core" version="2.13.56" targetFramework="net461" />
+  <package id="VirtoCommerce.Platform.Data" version="2.13.56" targetFramework="net461" />
 </packages>

--- a/CSharp/VirtoCommerce.OrderExModule.Template/Data/_packages.config
+++ b/CSharp/VirtoCommerce.OrderExModule.Template/Data/_packages.config
@@ -6,7 +6,7 @@
   <package id="Common.Logging.Core" version="3.3.1" targetFramework="net461" />
   <package id="EntityFramework" version="6.2.0" targetFramework="net461" />
   <package id="Hangfire.Core" version="1.6.17" targetFramework="net461" />
-  <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net461" />
+  <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net461" />
   <package id="Owin" version="1.0" targetFramework="net461" />
   <package id="valueinjecter" version="2.3.3" targetFramework="net461" />
   <package id="VirtoCommerce.CartModule.Data" version="2.17.1" targetFramework="net461" />

--- a/CSharp/VirtoCommerce.OrderExModule.Template/Tests/Tests.csproj
+++ b/CSharp/VirtoCommerce.OrderExModule.Template/Tests/Tests.csproj
@@ -63,7 +63,7 @@
       <HintPath>$nugetpackagesfolder$Hangfire.Core.1.6.17\lib\net45\Hangfire.Core.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>$nugetpackagesfolder$Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>$nugetpackagesfolder$Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="Omu.ValueInjecter, Version=2.3.3.0, Culture=neutral, PublicKeyToken=c7694541b0ac80e4, processorArchitecture=MSIL">
       <HintPath>$nugetpackagesfolder$valueinjecter.2.3.3\lib\net35\Omu.ValueInjecter.dll</HintPath>

--- a/CSharp/VirtoCommerce.OrderExModule.Template/Tests/Tests.csproj
+++ b/CSharp/VirtoCommerce.OrderExModule.Template/Tests/Tests.csproj
@@ -44,17 +44,17 @@
     <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
       <HintPath>$nugetpackagesfolder$Castle.Core.4.4.0\lib\net45\Castle.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Common.Logging, Version=3.3.1.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
-      <HintPath>$nugetpackagesfolder$Common.Logging.3.3.1\lib\net40\Common.Logging.dll</HintPath>
+    <Reference Include="Common.Logging, Version=3.4.1.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
+      <HintPath>$nugetpackagesfolder$Common.Logging.3.4.1\lib\net40\Common.Logging.dll</HintPath>
     </Reference>
-    <Reference Include="Common.Logging.Core, Version=3.3.1.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
-      <HintPath>$nugetpackagesfolder$Common.Logging.Core.3.3.1\lib\net40\Common.Logging.Core.dll</HintPath>
+    <Reference Include="Common.Logging.Core, Version=3.4.1.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
+      <HintPath>$nugetpackagesfolder$Common.Logging.Core.3.4.1\lib\net40\Common.Logging.Core.dll</HintPath>
     </Reference>
     <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
-      <HintPath>$nugetpackagesfolder$EntityFramework.6.2.0\lib\net45\EntityFramework.dll</HintPath>
+      <HintPath>$nugetpackagesfolder$EntityFramework.6.3.0\lib\net45\EntityFramework.dll</HintPath>
     </Reference>
     <Reference Include="EntityFramework.SqlServer, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
-      <HintPath>$nugetpackagesfolder$EntityFramework.6.2.0\lib\net45\EntityFramework.SqlServer.dll</HintPath>
+      <HintPath>$nugetpackagesfolder$EntityFramework.6.3.0\lib\net45\EntityFramework.SqlServer.dll</HintPath>
     </Reference>
     <Reference Include="Moq, Version=4.12.0.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
       <HintPath>$nugetpackagesfolder$Moq.4.12.0\lib\net45\Moq.dll</HintPath>
@@ -100,11 +100,11 @@
     <Reference Include="VirtoCommerce.OrderModule.Data, Version=2.17.29.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>$nugetpackagesfolder$VirtoCommerce.OrderModule.Data.2.17.29\lib\net461\VirtoCommerce.OrderModule.Data.dll</HintPath>
     </Reference>
-    <Reference Include="VirtoCommerce.Platform.Core, Version=2.13.55.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>$nugetpackagesfolder$VirtoCommerce.Platform.Core.2.13.55\lib\net461\VirtoCommerce.Platform.Core.dll</HintPath>
+    <Reference Include="VirtoCommerce.Platform.Core, Version=2.13.56.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>$nugetpackagesfolder$VirtoCommerce.Platform.Core.2.13.56\lib\net461\VirtoCommerce.Platform.Core.dll</HintPath>
     </Reference>
-    <Reference Include="VirtoCommerce.Platform.Data, Version=2.13.55.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>$nugetpackagesfolder$VirtoCommerce.Platform.Data.2.13.55\lib\net461\VirtoCommerce.Platform.Data.dll</HintPath>
+    <Reference Include="VirtoCommerce.Platform.Data, Version=2.13.56.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>$nugetpackagesfolder$VirtoCommerce.Platform.Data.2.13.56\lib\net461\VirtoCommerce.Platform.Data.dll</HintPath>
     </Reference>
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <HintPath>$nugetpackagesfolder$xunit.abstractions.2.0.3\lib\net35\xunit.abstractions.dll</HintPath>

--- a/CSharp/VirtoCommerce.OrderExModule.Template/Tests/_packages.config
+++ b/CSharp/VirtoCommerce.OrderExModule.Template/Tests/_packages.config
@@ -8,7 +8,7 @@
   <package id="EntityFramework" version="6.2.0" targetFramework="net461" />
   <package id="Moq" version="4.12.0" targetFramework="net461" />
   <package id="Hangfire.Core" version="1.6.17" targetFramework="net461" />
-  <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net461" />
+  <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net461" />
   <package id="Owin" version="1.0" targetFramework="net461" />
   <package id="StackExchange.Redis" version="1.2.6" targetFramework="net461" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.2" targetFramework="net461" />

--- a/CSharp/VirtoCommerce.OrderExModule.Template/Tests/_packages.config
+++ b/CSharp/VirtoCommerce.OrderExModule.Template/Tests/_packages.config
@@ -3,9 +3,9 @@
   <package id="AutoCompare" version="0.3.0.53" targetFramework="net461" />
   <package id="Castle.Core" version="4.4.0" targetFramework="net461" />
   <package id="CacheManager.Core" version="0.8.0" targetFramework="net461" />
-  <package id="Common.Logging" version="3.3.1" targetFramework="net461" />
-  <package id="Common.Logging.Core" version="3.3.1" targetFramework="net461" />
-  <package id="EntityFramework" version="6.2.0" targetFramework="net461" />
+  <package id="Common.Logging" version="3.4.1" targetFramework="net461" />
+  <package id="Common.Logging.Core" version="3.4.1" targetFramework="net461" />
+  <package id="EntityFramework" version="6.3.0" targetFramework="net461" />
   <package id="Moq" version="4.12.0" targetFramework="net461" />
   <package id="Hangfire.Core" version="1.6.17" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net461" />
@@ -17,8 +17,8 @@
   <package id="VirtoCommerce.CartModule.Data" version="2.17.1" targetFramework="net461" />
   <package id="VirtoCommerce.Domain" version="2.25.32" targetFramework="net461" />
   <package id="VirtoCommerce.OrderModule.Data" version="2.17.29" targetFramework="net461" />
-  <package id="VirtoCommerce.Platform.Core" version="2.13.55" targetFramework="net461" />
-  <package id="VirtoCommerce.Platform.Data" version="2.13.55" targetFramework="net461" />
+  <package id="VirtoCommerce.Platform.Core" version="2.13.56" targetFramework="net461" />
+  <package id="VirtoCommerce.Platform.Data" version="2.13.56" targetFramework="net461" />
   <package id="xunit" version="2.4.1" targetFramework="net461" />
   <package id="xunit.abstractions" version="2.0.3" targetFramework="net461" />
   <package id="xunit.analyzers" version="0.10.0" targetFramework="net461" />

--- a/CSharp/VirtoCommerce.OrderExModule.Template/Web/Web.csproj
+++ b/CSharp/VirtoCommerce.OrderExModule.Template/Web/Web.csproj
@@ -84,7 +84,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>$nugetpackagesfolder$Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>$nugetpackagesfolder$Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="Omu.ValueInjecter, Version=2.3.3.0, Culture=neutral, PublicKeyToken=c7694541b0ac80e4, processorArchitecture=MSIL">
       <HintPath>$nugetpackagesfolder$valueinjecter.2.3.3\lib\net35\Omu.ValueInjecter.dll</HintPath>

--- a/CSharp/VirtoCommerce.OrderExModule.Template/Web/Web.csproj
+++ b/CSharp/VirtoCommerce.OrderExModule.Template/Web/Web.csproj
@@ -51,17 +51,17 @@
     <Reference Include="CacheManager.Core, Version=0.8.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>$nugetpackagesfolder$CacheManager.Core.0.8.0\lib\net45\CacheManager.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Common.Logging, Version=3.3.1.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
-      <HintPath>$nugetpackagesfolder$Common.Logging.3.3.1\lib\net40\Common.Logging.dll</HintPath>
+    <Reference Include="Common.Logging, Version=3.4.1.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
+      <HintPath>$nugetpackagesfolder$Common.Logging.3.4.1\lib\net40\Common.Logging.dll</HintPath>
     </Reference>
-    <Reference Include="Common.Logging.Core, Version=3.3.1.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
-      <HintPath>$nugetpackagesfolder$Common.Logging.Core.3.3.1\lib\net40\Common.Logging.Core.dll</HintPath>
+    <Reference Include="Common.Logging.Core, Version=3.4.1.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
+      <HintPath>$nugetpackagesfolder$Common.Logging.Core.3.4.1\lib\net40\Common.Logging.Core.dll</HintPath>
     </Reference>
     <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
-      <HintPath>$nugetpackagesfolder$EntityFramework.6.2.0\lib\net45\EntityFramework.dll</HintPath>
+      <HintPath>$nugetpackagesfolder$EntityFramework.6.3.0\lib\net45\EntityFramework.dll</HintPath>
     </Reference>
     <Reference Include="EntityFramework.SqlServer, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
-      <HintPath>$nugetpackagesfolder$EntityFramework.6.2.0\lib\net45\EntityFramework.SqlServer.dll</HintPath>
+      <HintPath>$nugetpackagesfolder$EntityFramework.6.3.0\lib\net45\EntityFramework.SqlServer.dll</HintPath>
     </Reference>
     <Reference Include="Hangfire.Core, Version=1.6.17.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>$nugetpackagesfolder$Hangfire.Core.1.6.17\lib\net45\Hangfire.Core.dll</HintPath>
@@ -126,11 +126,11 @@
     <Reference Include="VirtoCommerce.OrderModule.Data, Version=2.17.29.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>$nugetpackagesfolder$VirtoCommerce.OrderModule.Data.2.17.29\lib\net461\VirtoCommerce.OrderModule.Data.dll</HintPath>
     </Reference>
-    <Reference Include="VirtoCommerce.Platform.Core, Version=2.13.55.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>$nugetpackagesfolder$VirtoCommerce.Platform.Core.2.13.55\lib\net461\VirtoCommerce.Platform.Core.dll</HintPath>
+    <Reference Include="VirtoCommerce.Platform.Core, Version=2.13.56.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>$nugetpackagesfolder$VirtoCommerce.Platform.Core.2.13.56\lib\net461\VirtoCommerce.Platform.Core.dll</HintPath>
     </Reference>
-    <Reference Include="VirtoCommerce.Platform.Data, Version=2.13.55.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>$nugetpackagesfolder$VirtoCommerce.Platform.Data.2.13.55\lib\net461\VirtoCommerce.Platform.Data.dll</HintPath>
+    <Reference Include="VirtoCommerce.Platform.Data, Version=2.13.56.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>$nugetpackagesfolder$VirtoCommerce.Platform.Data.2.13.56\lib\net461\VirtoCommerce.Platform.Data.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/CSharp/VirtoCommerce.OrderExModule.Template/Web/_packages.config
+++ b/CSharp/VirtoCommerce.OrderExModule.Template/Web/_packages.config
@@ -10,7 +10,7 @@
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.7" targetFramework="net461" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.7" targetFramework="net461" />
   <package id="MSBuildTasks" version="1.5.0.235" targetFramework="net461" developmentDependency="true" />
-  <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net461" />
+  <<package id="Newtonsoft.Json" version="12.0.2" targetFramework="net461" />
   <package id="Owin" version="1.0" targetFramework="net461" />
   <package id="StackExchange.Redis" version="1.2.6" targetFramework="net461" />
   <package id="Unity" version="4.0.1" targetFramework="net461" />

--- a/CSharp/VirtoCommerce.OrderExModule.Template/Web/_packages.config
+++ b/CSharp/VirtoCommerce.OrderExModule.Template/Web/_packages.config
@@ -2,15 +2,15 @@
 <packages>
   <package id="AutoCompare" version="0.3.0.53" targetFramework="net461" />
   <package id="CacheManager.Core" version="0.8.0" targetFramework="net461" />
-  <package id="Common.Logging" version="3.3.1" targetFramework="net461" />
-  <package id="Common.Logging.Core" version="3.3.1" targetFramework="net461" />
+  <package id="Common.Logging" version="3.4.1" targetFramework="net461" />
+  <package id="Common.Logging.Core" version="3.4.1" targetFramework="net461" />
   <package id="CommonServiceLocator" version="1.3" targetFramework="net461" />
-  <package id="EntityFramework" version="6.2.0" targetFramework="net461" />
+  <package id="EntityFramework" version="6.3.0" targetFramework="net461" />
   <package id="Hangfire.Core" version="1.6.17" targetFramework="net461" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.7" targetFramework="net461" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.7" targetFramework="net461" />
   <package id="MSBuildTasks" version="1.5.0.235" targetFramework="net461" developmentDependency="true" />
-  <<package id="Newtonsoft.Json" version="12.0.2" targetFramework="net461" />
+  <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net461" />
   <package id="Owin" version="1.0" targetFramework="net461" />
   <package id="StackExchange.Redis" version="1.2.6" targetFramework="net461" />
   <package id="Unity" version="4.0.1" targetFramework="net461" />
@@ -19,6 +19,6 @@
   <package id="VirtoCommerce.Domain" version="2.25.32" targetFramework="net461" />
   <package id="VirtoCommerce.Module" version="0.18.0" targetFramework="net461" developmentDependency="true" />
   <package id="VirtoCommerce.OrderModule.Data" version="2.17.29" targetFramework="net461" />
-  <package id="VirtoCommerce.Platform.Core" version="2.13.55" targetFramework="net461" />
-  <package id="VirtoCommerce.Platform.Data" version="2.13.55" targetFramework="net461" />
+  <package id="VirtoCommerce.Platform.Core" version="2.13.56" targetFramework="net461" />
+  <package id="VirtoCommerce.Platform.Data" version="2.13.56" targetFramework="net461" />
 </packages>

--- a/CSharp/VirtoCommerce.OrderExModule.Template/Web/module.manifest
+++ b/CSharp/VirtoCommerce.OrderExModule.Template/Web/module.manifest
@@ -2,7 +2,7 @@
 <module>
     <id>$ext_safeprojectname$</id>
     <version>1.0.0</version>
-    <platformVersion>2.13.55</platformVersion>
+    <platformVersion>2.13.56</platformVersion>
     <dependencies>
       <dependency id="VirtoCommerce.Cart" version="2.17.1" />
       <dependency id="VirtoCommerce.Core" version="2.25.32" />

--- a/CSharp/VirtoCommerce.PriceExModule.Template/Core/Core.csproj
+++ b/CSharp/VirtoCommerce.PriceExModule.Template/Core/Core.csproj
@@ -45,8 +45,8 @@
     <Reference Include="VirtoCommerce.Domain, Version=2.25.32.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>$nugetpackagesfolder$VirtoCommerce.Domain.2.25.32\lib\net461\VirtoCommerce.Domain.dll</HintPath>
     </Reference>
-    <Reference Include="VirtoCommerce.Platform.Core, Version=2.13.55.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>$nugetpackagesfolder$VirtoCommerce.Platform.Core.2.13.55\lib\net461\VirtoCommerce.Platform.Core.dll</HintPath>
+    <Reference Include="VirtoCommerce.Platform.Core, Version=2.13.56.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>$nugetpackagesfolder$VirtoCommerce.Platform.Core.2.13.56\lib\net461\VirtoCommerce.Platform.Core.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/CSharp/VirtoCommerce.PriceExModule.Template/Core/Core.csproj
+++ b/CSharp/VirtoCommerce.PriceExModule.Template/Core/Core.csproj
@@ -32,7 +32,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>$nugetpackagesfolder$Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>$nugetpackagesfolder$Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/CSharp/VirtoCommerce.PriceExModule.Template/Core/_packages.config
+++ b/CSharp/VirtoCommerce.PriceExModule.Template/Core/_packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net461" />
+  <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net461" />
   <package id="VirtoCommerce.Domain" version="2.25.32" targetFramework="net461" />
   <package id="VirtoCommerce.Platform.Core" version="2.13.55" targetFramework="net461" />
 </packages>

--- a/CSharp/VirtoCommerce.PriceExModule.Template/Core/_packages.config
+++ b/CSharp/VirtoCommerce.PriceExModule.Template/Core/_packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net461" />
   <package id="VirtoCommerce.Domain" version="2.25.32" targetFramework="net461" />
-  <package id="VirtoCommerce.Platform.Core" version="2.13.55" targetFramework="net461" />
+  <package id="VirtoCommerce.Platform.Core" version="2.13.56" targetFramework="net461" />
 </packages>

--- a/CSharp/VirtoCommerce.PriceExModule.Template/Data/Data.csproj
+++ b/CSharp/VirtoCommerce.PriceExModule.Template/Data/Data.csproj
@@ -47,7 +47,7 @@
       <HintPath>$nugetpackagesfolder$EntityFramework.6.2.0\lib\net45\EntityFramework.SqlServer.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>$nugetpackagesfolder$Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>$nugetpackagesfolder$Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="Omu.ValueInjecter, Version=2.3.3.0, Culture=neutral, PublicKeyToken=c7694541b0ac80e4, processorArchitecture=MSIL">
       <HintPath>$nugetpackagesfolder$valueinjecter.2.3.3\lib\net35\Omu.ValueInjecter.dll</HintPath>

--- a/CSharp/VirtoCommerce.PriceExModule.Template/Data/Data.csproj
+++ b/CSharp/VirtoCommerce.PriceExModule.Template/Data/Data.csproj
@@ -34,17 +34,20 @@
     <Reference Include="CacheManager.Core, Version=0.8.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>$nugetpackagesfolder$CacheManager.Core.0.8.0\lib\net45\CacheManager.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Common.Logging, Version=3.3.1.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
-      <HintPath>$nugetpackagesfolder$Common.Logging.3.3.1\lib\net40\Common.Logging.dll</HintPath>
+    <Reference Include="Common.Logging, Version=3.4.1.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
+      <HintPath>$nugetpackagesfolder$Common.Logging.3.4.1\lib\net40\Common.Logging.dll</HintPath>
     </Reference>
-    <Reference Include="Common.Logging.Core, Version=3.3.1.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
-      <HintPath>$nugetpackagesfolder$Common.Logging.Core.3.3.1\lib\net40\Common.Logging.Core.dll</HintPath>
+    <Reference Include="Common.Logging.Core, Version=3.4.1.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
+      <HintPath>$nugetpackagesfolder$Common.Logging.Core.3.4.1\lib\net40\Common.Logging.Core.dll</HintPath>
     </Reference>
     <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
-      <HintPath>$nugetpackagesfolder$EntityFramework.6.2.0\lib\net45\EntityFramework.dll</HintPath>
+      <HintPath>$nugetpackagesfolder$EntityFramework.6.3.0\lib\net45\EntityFramework.dll</HintPath>
     </Reference>
     <Reference Include="EntityFramework.SqlServer, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
-      <HintPath>$nugetpackagesfolder$EntityFramework.6.2.0\lib\net45\EntityFramework.SqlServer.dll</HintPath>
+      <HintPath>$nugetpackagesfolder$EntityFramework.6.3.0\lib\net45\EntityFramework.SqlServer.dll</HintPath>
+    </Reference>
+        <Reference Include="Hangfire.Core, Version=1.6.7.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Hangfire.Core.1.6.7\lib\net45\Hangfire.Core.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>$nugetpackagesfolder$Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
@@ -52,10 +55,16 @@
     <Reference Include="Omu.ValueInjecter, Version=2.3.3.0, Culture=neutral, PublicKeyToken=c7694541b0ac80e4, processorArchitecture=MSIL">
       <HintPath>$nugetpackagesfolder$valueinjecter.2.3.3\lib\net35\Omu.ValueInjecter.dll</HintPath>
     </Reference>
+    <Reference Include="Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f0ebd12fd5e55cc5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
+    <Reference Include="System.ValueTuple, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.ValueTuple.4.4.0\lib\net461\System.ValueTuple.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -65,11 +74,17 @@
     <Reference Include="VirtoCommerce.Domain, Version=2.25.32.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>$nugetpackagesfolder$VirtoCommerce.Domain.2.25.32\lib\net461\VirtoCommerce.Domain.dll</HintPath>
     </Reference>
-    <Reference Include="VirtoCommerce.Platform.Core, Version=2.13.55.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>$nugetpackagesfolder$VirtoCommerce.Platform.Core.2.13.55\lib\net461\VirtoCommerce.Platform.Core.dll</HintPath>
+    <Reference Include="VirtoCommerce.ExportModule.Core, Version=2.1.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\VirtoCommerce.ExportModule.Core.2.1.1\lib\net461\VirtoCommerce.ExportModule.Core.dll</HintPath>
     </Reference>
-    <Reference Include="VirtoCommerce.Platform.Data, Version=2.13.55.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>$nugetpackagesfolder$VirtoCommerce.Platform.Data.2.13.55\lib\net461\VirtoCommerce.Platform.Data.dll</HintPath>
+    <Reference Include="VirtoCommerce.ExportModule.Data, Version=2.1.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\VirtoCommerce.ExportModule.Data.2.1.1\lib\net461\VirtoCommerce.ExportModule.Data.dll</HintPath>
+    </Reference>
+    <Reference Include="VirtoCommerce.Platform.Core, Version=2.13.56.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>$nugetpackagesfolder$VirtoCommerce.Platform.Core.2.13.56\lib\net461\VirtoCommerce.Platform.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="VirtoCommerce.Platform.Data, Version=2.13.56.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>$nugetpackagesfolder$VirtoCommerce.Platform.Data.2.13.56\lib\net461\VirtoCommerce.Platform.Data.dll</HintPath>
     </Reference>
     <Reference Include="VirtoCommerce.PricingModule.Data, Version=2.18.10.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>$nugetpackagesfolder$VirtoCommerce.PricingModule.Data.2.18.10\lib\net461\VirtoCommerce.PricingModule.Data.dll</HintPath>

--- a/CSharp/VirtoCommerce.PriceExModule.Template/Data/_packages.config
+++ b/CSharp/VirtoCommerce.PriceExModule.Template/Data/_packages.config
@@ -4,7 +4,7 @@
   <package id="Common.Logging" version="3.3.1" targetFramework="net461" />
   <package id="Common.Logging.Core" version="3.3.1" targetFramework="net461" />
   <package id="EntityFramework" version="6.2.0" targetFramework="net461" />
-  <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net461" />
+  <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net461" />
   <package id="valueinjecter" version="2.3.3" targetFramework="net461" />
   <package id="VirtoCommerce.Domain" version="2.25.32" targetFramework="net461" />
   <package id="VirtoCommerce.Platform.Core" version="2.13.55" targetFramework="net461" />

--- a/CSharp/VirtoCommerce.PriceExModule.Template/Data/_packages.config
+++ b/CSharp/VirtoCommerce.PriceExModule.Template/Data/_packages.config
@@ -1,13 +1,18 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CacheManager.Core" version="0.8.0" targetFramework="net461" />
-  <package id="Common.Logging" version="3.3.1" targetFramework="net461" />
-  <package id="Common.Logging.Core" version="3.3.1" targetFramework="net461" />
-  <package id="EntityFramework" version="6.2.0" targetFramework="net461" />
+  <package id="Common.Logging" version="3.4.1" targetFramework="net461" />
+  <package id="Common.Logging.Core" version="3.4.1" targetFramework="net461" />
+  <package id="EntityFramework" version="6.3.0" targetFramework="net461" />
+  <package id="Hangfire.Core" version="1.6.7" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net461" />
+  <package id="Owin" version="1.0" targetFramework="net461" />
+  <package id="System.ValueTuple" version="4.4.0" targetFramework="net461" />
   <package id="valueinjecter" version="2.3.3" targetFramework="net461" />
   <package id="VirtoCommerce.Domain" version="2.25.32" targetFramework="net461" />
-  <package id="VirtoCommerce.Platform.Core" version="2.13.55" targetFramework="net461" />
-  <package id="VirtoCommerce.Platform.Data" version="2.13.55" targetFramework="net461" />
+  <package id="VirtoCommerce.ExportModule.Core" version="2.1.1" targetFramework="net461" />
+  <package id="VirtoCommerce.ExportModule.Data" version="2.1.1" targetFramework="net461" />
+  <package id="VirtoCommerce.Platform.Core" version="2.13.56" targetFramework="net461" />
+  <package id="VirtoCommerce.Platform.Data" version="2.13.56" targetFramework="net461" />
   <package id="VirtoCommerce.PricingModule.Data" version="2.18.10" targetFramework="net461" />
 </packages>

--- a/CSharp/VirtoCommerce.PriceExModule.Template/Tests/Tests.csproj
+++ b/CSharp/VirtoCommerce.PriceExModule.Template/Tests/Tests.csproj
@@ -41,17 +41,20 @@
     <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
       <HintPath>$nugetpackagesfolder$Castle.Core.4.4.0\lib\net45\Castle.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Common.Logging, Version=3.3.1.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
-      <HintPath>$nugetpackagesfolder$Common.Logging.3.3.1\lib\net40\Common.Logging.dll</HintPath>
+    <Reference Include="Common.Logging, Version=3.4.1.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
+      <HintPath>$nugetpackagesfolder$Common.Logging.3.4.1\lib\net40\Common.Logging.dll</HintPath>
     </Reference>
-    <Reference Include="Common.Logging.Core, Version=3.3.1.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
-      <HintPath>$nugetpackagesfolder$Common.Logging.Core.3.3.1\lib\net40\Common.Logging.Core.dll</HintPath>
+    <Reference Include="Common.Logging.Core, Version=3.4.1.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
+      <HintPath>$nugetpackagesfolder$Common.Logging.Core.3.4.1\lib\net40\Common.Logging.Core.dll</HintPath>
     </Reference>
     <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
-      <HintPath>$nugetpackagesfolder$EntityFramework.6.2.0\lib\net45\EntityFramework.dll</HintPath>
+      <HintPath>$nugetpackagesfolder$EntityFramework.6.3.0\lib\net45\EntityFramework.dll</HintPath>
     </Reference>
     <Reference Include="EntityFramework.SqlServer, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
-      <HintPath>$nugetpackagesfolder$EntityFramework.6.2.0\lib\net45\EntityFramework.SqlServer.dll</HintPath>
+      <HintPath>$nugetpackagesfolder$EntityFramework.6.3.0\lib\net45\EntityFramework.SqlServer.dll</HintPath>
+    </Reference>
+    <Reference Include="Hangfire.Core, Version=1.6.7.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Hangfire.Core.1.6.7\lib\net45\Hangfire.Core.dll</HintPath>
     </Reference>
     <Reference Include="Moq, Version=4.12.0.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
       <HintPath>$nugetpackagesfolder$Moq.4.12.0\lib\net45\Moq.dll</HintPath>
@@ -61,6 +64,9 @@
     </Reference>
     <Reference Include="Omu.ValueInjecter, Version=2.3.3.0, Culture=neutral, PublicKeyToken=c7694541b0ac80e4, processorArchitecture=MSIL">
       <HintPath>$nugetpackagesfolder$valueinjecter.2.3.3\lib\net35\Omu.ValueInjecter.dll</HintPath>
+    </Reference>
+    <Reference Include="Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f0ebd12fd5e55cc5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
@@ -72,6 +78,11 @@
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>$nugetpackagesfolder$System.Threading.Tasks.Extensions.4.5.1\lib\netstandard2.0\System.Threading.Tasks.Extensions.dll</HintPath>
     </Reference>
+    <Reference Include="System.ValueTuple, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.ValueTuple.4.4.0\lib\net461\System.ValueTuple.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -81,11 +92,17 @@
     <Reference Include="VirtoCommerce.Domain, Version=2.25.32.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>$nugetpackagesfolder$VirtoCommerce.Domain.2.25.32\lib\net461\VirtoCommerce.Domain.dll</HintPath>
     </Reference>
-    <Reference Include="VirtoCommerce.Platform.Core, Version=2.13.55.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>$nugetpackagesfolder$VirtoCommerce.Platform.Core.2.13.55\lib\net461\VirtoCommerce.Platform.Core.dll</HintPath>
+    <Reference Include="VirtoCommerce.Platform.Core, Version=2.13.56.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>$nugetpackagesfolder$VirtoCommerce.Platform.Core.2.13.56\lib\net461\VirtoCommerce.Platform.Core.dll</HintPath>
     </Reference>
-    <Reference Include="VirtoCommerce.Platform.Data, Version=2.13.55.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>$nugetpackagesfolder$VirtoCommerce.Platform.Data.2.13.55\lib\net461\VirtoCommerce.Platform.Data.dll</HintPath>
+    <Reference Include="VirtoCommerce.ExportModule.Core, Version=2.1.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\VirtoCommerce.ExportModule.Core.2.1.1\lib\net461\VirtoCommerce.ExportModule.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="VirtoCommerce.ExportModule.Data, Version=2.1.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\VirtoCommerce.ExportModule.Data.2.1.1\lib\net461\VirtoCommerce.ExportModule.Data.dll</HintPath>
+    </Reference>
+    <Reference Include="VirtoCommerce.Platform.Data, Version=2.13.56.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>$nugetpackagesfolder$VirtoCommerce.Platform.Data.2.13.56\lib\net461\VirtoCommerce.Platform.Data.dll</HintPath>
     </Reference>
     <Reference Include="VirtoCommerce.PricingModule.Data, Version=2.18.10.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>$nugetpackagesfolder$VirtoCommerce.PricingModule.Data.2.18.10\lib\net461\VirtoCommerce.PricingModule.Data.dll</HintPath>

--- a/CSharp/VirtoCommerce.PriceExModule.Template/Tests/Tests.csproj
+++ b/CSharp/VirtoCommerce.PriceExModule.Template/Tests/Tests.csproj
@@ -57,7 +57,7 @@
       <HintPath>$nugetpackagesfolder$Moq.4.12.0\lib\net45\Moq.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>$nugetpackagesfolder$Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>$nugetpackagesfolder$Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="Omu.ValueInjecter, Version=2.3.3.0, Culture=neutral, PublicKeyToken=c7694541b0ac80e4, processorArchitecture=MSIL">
       <HintPath>$nugetpackagesfolder$valueinjecter.2.3.3\lib\net35\Omu.ValueInjecter.dll</HintPath>

--- a/CSharp/VirtoCommerce.PriceExModule.Template/Tests/_packages.config
+++ b/CSharp/VirtoCommerce.PriceExModule.Template/Tests/_packages.config
@@ -2,17 +2,22 @@
 <packages>
   <package id="CacheManager.Core" version="0.8.0" targetFramework="net461" />
   <package id="Castle.Core" version="4.4.0" targetFramework="net461" />
-  <package id="Common.Logging" version="3.3.1" targetFramework="net461" />
-  <package id="Common.Logging.Core" version="3.3.1" targetFramework="net461" />
-  <package id="EntityFramework" version="6.2.0" targetFramework="net461" />
+  <package id="Common.Logging" version="3.4.1" targetFramework="net461" />
+  <package id="Common.Logging.Core" version="3.4.1" targetFramework="net461" />
+  <package id="EntityFramework" version="6.3.0" targetFramework="net461" />
+  <package id="Hangfire.Core" version="1.6.7" targetFramework="net461" />
   <package id="Moq" version="4.12.0" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net461" />
+  <package id="Owin" version="1.0" targetFramework="net461" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.2" targetFramework="net461" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.1" targetFramework="net461" />
+  <package id="System.ValueTuple" version="4.4.0" targetFramework="net461" />
   <package id="valueinjecter" version="2.3.3" targetFramework="net461" />
   <package id="VirtoCommerce.Domain" version="2.25.32" targetFramework="net461" />
-  <package id="VirtoCommerce.Platform.Core" version="2.13.55" targetFramework="net461" />
-  <package id="VirtoCommerce.Platform.Data" version="2.13.55" targetFramework="net461" />
+  <package id="VirtoCommerce.ExportModule.Core" version="2.1.1" targetFramework="net461" /> 
+  <package id="VirtoCommerce.ExportModule.Data" version="2.1.1" targetFramework="net461" />
+  <package id="VirtoCommerce.Platform.Core" version="2.13.56" targetFramework="net461" />
+  <package id="VirtoCommerce.Platform.Data" version="2.13.56" targetFramework="net461" />
   <package id="VirtoCommerce.PricingModule.Data" version="2.18.10" targetFramework="net461" />
   <package id="xunit" version="2.4.1" targetFramework="net461" />
   <package id="xunit.abstractions" version="2.0.3" targetFramework="net461" />

--- a/CSharp/VirtoCommerce.PriceExModule.Template/Tests/_packages.config
+++ b/CSharp/VirtoCommerce.PriceExModule.Template/Tests/_packages.config
@@ -6,7 +6,7 @@
   <package id="Common.Logging.Core" version="3.3.1" targetFramework="net461" />
   <package id="EntityFramework" version="6.2.0" targetFramework="net461" />
   <package id="Moq" version="4.12.0" targetFramework="net461" />
-  <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net461" />
+  <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net461" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.2" targetFramework="net461" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.1" targetFramework="net461" />
   <package id="valueinjecter" version="2.3.3" targetFramework="net461" />

--- a/CSharp/VirtoCommerce.PriceExModule.Template/Web/Web.config
+++ b/CSharp/VirtoCommerce.PriceExModule.Template/Web/Web.config
@@ -3,6 +3,10 @@
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
+        <assemblyIdentity name="Common.Logging.Core" publicKeyToken="af08829b84f0328e" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.4.1.0" newVersion="3.4.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
       </dependentAssembly>

--- a/CSharp/VirtoCommerce.PriceExModule.Template/Web/Web.csproj
+++ b/CSharp/VirtoCommerce.PriceExModule.Template/Web/Web.csproj
@@ -48,17 +48,20 @@
     <Reference Include="CacheManager.Core, Version=0.8.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>$nugetpackagesfolder$CacheManager.Core.0.8.0\lib\net45\CacheManager.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Common.Logging, Version=3.3.1.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
-      <HintPath>$nugetpackagesfolder$Common.Logging.3.3.1\lib\net40\Common.Logging.dll</HintPath>
+    <Reference Include="Common.Logging, Version=3.4.1.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
+      <HintPath>$nugetpackagesfolder$Common.Logging.3.4.1\lib\net40\Common.Logging.dll</HintPath>
     </Reference>
-    <Reference Include="Common.Logging.Core, Version=3.3.1.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
-      <HintPath>$nugetpackagesfolder$Common.Logging.Core.3.3.1\lib\net40\Common.Logging.Core.dll</HintPath>
+    <Reference Include="Common.Logging.Core, Version=3.4.1.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
+      <HintPath>$nugetpackagesfolder$Common.Logging.Core.3.4.1\lib\net40\Common.Logging.Core.dll</HintPath>
     </Reference>
     <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
-      <HintPath>$nugetpackagesfolder$EntityFramework.6.2.0\lib\net45\EntityFramework.dll</HintPath>
+      <HintPath>$nugetpackagesfolder$EntityFramework.6.3.0\lib\net45\EntityFramework.dll</HintPath>
     </Reference>
     <Reference Include="EntityFramework.SqlServer, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
-      <HintPath>$nugetpackagesfolder$EntityFramework.6.2.0\lib\net45\EntityFramework.SqlServer.dll</HintPath>
+      <HintPath>$nugetpackagesfolder$EntityFramework.6.3.0\lib\net45\EntityFramework.SqlServer.dll</HintPath>
+    </Reference>
+    <Reference Include="Hangfire.Core, Version=1.6.7.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Hangfire.Core.1.6.7\lib\net45\Hangfire.Core.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.Practices.ServiceLocation, Version=1.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -83,10 +86,16 @@
     <Reference Include="Omu.ValueInjecter, Version=2.3.3.0, Culture=neutral, PublicKeyToken=c7694541b0ac80e4, processorArchitecture=MSIL">
       <HintPath>$nugetpackagesfolder$valueinjecter.2.3.3\lib\net35\Omu.ValueInjecter.dll</HintPath>
     </Reference>
+    <Reference Include="Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f0ebd12fd5e55cc5, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
+    </Reference>
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Net.Http.Formatting, Version=5.2.7.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>$nugetpackagesfolder$Microsoft.AspNet.WebApi.Client.5.2.7\lib\net45\System.Net.Http.Formatting.dll</HintPath>
       <Private>True</Private>
+    </Reference>
+    <Reference Include="System.ValueTuple, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.ValueTuple.4.4.0\lib\net461\System.ValueTuple.dll</HintPath>
     </Reference>
     <Reference Include="System.Web.DynamicData" />
     <Reference Include="System.Web.Entity" />
@@ -107,11 +116,17 @@
     <Reference Include="VirtoCommerce.Domain, Version=2.25.32.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>$nugetpackagesfolder$VirtoCommerce.Domain.2.25.32\lib\net461\VirtoCommerce.Domain.dll</HintPath>
     </Reference>
-    <Reference Include="VirtoCommerce.Platform.Core, Version=2.13.55.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>$nugetpackagesfolder$VirtoCommerce.Platform.Core.2.13.55\lib\net461\VirtoCommerce.Platform.Core.dll</HintPath>
+    <Reference Include="VirtoCommerce.ExportModule.Core, Version=2.1.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\VirtoCommerce.ExportModule.Core.2.1.1\lib\net461\VirtoCommerce.ExportModule.Core.dll</HintPath>
     </Reference>
-    <Reference Include="VirtoCommerce.Platform.Data, Version=2.13.55.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>$nugetpackagesfolder$VirtoCommerce.Platform.Data.2.13.55\lib\net461\VirtoCommerce.Platform.Data.dll</HintPath>
+    <Reference Include="VirtoCommerce.ExportModule.Data, Version=2.1.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\VirtoCommerce.ExportModule.Data.2.1.1\lib\net461\VirtoCommerce.ExportModule.Data.dll</HintPath>
+    </Reference>
+    <Reference Include="VirtoCommerce.Platform.Core, Version=2.13.56.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>$nugetpackagesfolder$VirtoCommerce.Platform.Core.2.13.56\lib\net461\VirtoCommerce.Platform.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="VirtoCommerce.Platform.Data, Version=2.13.56.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>$nugetpackagesfolder$VirtoCommerce.Platform.Data.2.13.56\lib\net461\VirtoCommerce.Platform.Data.dll</HintPath>
     </Reference>
     <Reference Include="VirtoCommerce.PricingModule.Data, Version=2.18.10.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>$nugetpackagesfolder$VirtoCommerce.PricingModule.Data.2.18.10\lib\net461\VirtoCommerce.PricingModule.Data.dll</HintPath>

--- a/CSharp/VirtoCommerce.PriceExModule.Template/Web/Web.csproj
+++ b/CSharp/VirtoCommerce.PriceExModule.Template/Web/Web.csproj
@@ -78,7 +78,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>$nugetpackagesfolder$Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>$nugetpackagesfolder$Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="Omu.ValueInjecter, Version=2.3.3.0, Culture=neutral, PublicKeyToken=c7694541b0ac80e4, processorArchitecture=MSIL">
       <HintPath>$nugetpackagesfolder$valueinjecter.2.3.3\lib\net35\Omu.ValueInjecter.dll</HintPath>

--- a/CSharp/VirtoCommerce.PriceExModule.Template/Web/_packages.config
+++ b/CSharp/VirtoCommerce.PriceExModule.Template/Web/_packages.config
@@ -1,19 +1,24 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CacheManager.Core" version="0.8.0" targetFramework="net461" />
-  <package id="Common.Logging" version="3.3.1" targetFramework="net461" />
-  <package id="Common.Logging.Core" version="3.3.1" targetFramework="net461" />
+  <package id="Common.Logging" version="3.4.1" targetFramework="net461" />
+  <package id="Common.Logging.Core" version="3.4.1" targetFramework="net461" />
   <package id="CommonServiceLocator" version="1.3" targetFramework="net461" />
-  <package id="EntityFramework" version="6.2.0" targetFramework="net461" />
+  <package id="EntityFramework" version="6.3.0" targetFramework="net461" />
+  <package id="Hangfire.Core" version="1.6.7" targetFramework="net461" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.7" targetFramework="net461" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.7" targetFramework="net461" />
   <package id="MSBuildTasks" version="1.5.0.235" targetFramework="net461" developmentDependency="true" />
   <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net461" />
+  <package id="Owin" version="1.0" targetFramework="net461" />
+  <package id="System.ValueTuple" version="4.4.0" targetFramework="net461" />
   <package id="Unity" version="4.0.1" targetFramework="net461" />
   <package id="valueinjecter" version="2.3.3" targetFramework="net461" />
   <package id="VirtoCommerce.Domain" version="2.25.32" targetFramework="net461" />
+  <package id="VirtoCommerce.ExportModule.Core" version="2.1.1" targetFramework="net461" />
+  <package id="VirtoCommerce.ExportModule.Data" version="2.1.1" targetFramework="net461" />
   <package id="VirtoCommerce.Module" version="0.18.0" targetFramework="net461" developmentDependency="true" />
-  <package id="VirtoCommerce.Platform.Core" version="2.13.55" targetFramework="net461" />
-  <package id="VirtoCommerce.Platform.Data" version="2.13.55" targetFramework="net461" />
+  <package id="VirtoCommerce.Platform.Core" version="2.13.56" targetFramework="net461" />
+  <package id="VirtoCommerce.Platform.Data" version="2.13.56" targetFramework="net461" />
   <package id="VirtoCommerce.PricingModule.Data" version="2.18.10" targetFramework="net461" />
 </packages>

--- a/CSharp/VirtoCommerce.PriceExModule.Template/Web/_packages.config
+++ b/CSharp/VirtoCommerce.PriceExModule.Template/Web/_packages.config
@@ -8,7 +8,7 @@
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.7" targetFramework="net461" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.7" targetFramework="net461" />
   <package id="MSBuildTasks" version="1.5.0.235" targetFramework="net461" developmentDependency="true" />
-  <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net461" />
+  <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net461" />
   <package id="Unity" version="4.0.1" targetFramework="net461" />
   <package id="valueinjecter" version="2.3.3" targetFramework="net461" />
   <package id="VirtoCommerce.Domain" version="2.25.32" targetFramework="net461" />

--- a/CSharp/VirtoCommerce.PriceExModule.Template/Web/module.manifest
+++ b/CSharp/VirtoCommerce.PriceExModule.Template/Web/module.manifest
@@ -2,7 +2,7 @@
 <module>
     <id>$ext_safeprojectname$</id>
     <version>1.0.0</version>
-    <platformVersion>2.13.55</platformVersion>
+    <platformVersion>2.13.56</platformVersion>
     <dependencies>
       <dependency id="VirtoCommerce.Core" version="2.25.32" />
       <dependency id="VirtoCommerce.Pricing" version="2.18.10" />


### PR DESCRIPTION
**Update related packages versions**

Update **platform** to 2.13.56
Updates for **Module, OrederEx, PricingEx, CustomerEx**:
Newtonsoft.Json.11.0.2 -> Newtonsoft.Json.12.0.2
Common.Logging.3.3.1 -> Common.Logging.3.4.1
Common.Logging.Core.3.3.1 -> Common.Logging.Core.3.4.1
EntityFramework.6.2.0 -> EntityFramework.6.3.0

Updates for **OrederEx**:
 -> StackExchange.Redis.1.2.6

Updates for **PricingEx**:
 -> Owin.1.0.0
 -> Hangfire.Core.1.6.7
 -> System.ValueTuple.4.4.0
 -> VirtoCommerce.ExportModule.Core.2.1.1
 -> VirtoCommerce.ExportModule.Data.2.1.1

**Added settings grouping by module name for a new module template in module manifest**

Related tasks: CCIT-294 CCIT-296